### PR TITLE
[WIP] Atomic promotions.

### DIFF
--- a/src/HydrocarbonNets.jl
+++ b/src/HydrocarbonNets.jl
@@ -2,7 +2,7 @@ module HydrocarbonNets
 
 using Compat
 
-import Base: ==, push!, show
+import Base: ==, promotion_rule, push!, show
 
        # atomic_units.jl
 export AtomicUnit, Hydrogen, H, Carbon, C,

--- a/src/HydrocarbonNets.jl
+++ b/src/HydrocarbonNets.jl
@@ -2,7 +2,7 @@ module HydrocarbonNets
 
 using Compat
 
-import Base: ==, promotion_rule, push!, show
+import Base: ==, promote_rule, push!, show
 
        # atomic_units.jl
 export AtomicUnit, Hydrogen, H, Carbon, C,

--- a/src/atomic_units.jl
+++ b/src/atomic_units.jl
@@ -1,38 +1,43 @@
 abstract AtomicUnit{T}
 
-const atoms_data = [
-    # Variable       Name   Symbol  Valence
-    (:hydrogen, :Hydrogen,  :H,     1),
-    (  :carbon,   :Carbon,  :C,     4)
+const atoms_meta = [
+    #     Name   Symbol  Valence
+    (:Hydrogen,  :H,     1),
+    (  :Carbon,  :C,     4)
 ]
 
-const atoms = Dict{Symbol, Tuple}[]
+const atoms_data = [
+    @compat Dict(
+        :name => name,
+        :symbol => symbol,
+        :valence => valence
+    ) for (name, symbol, valence) in atoms_meta
+]
 
-for (variable, name, symbol, valence) in atoms_data
-    @eval const $variable = Dict(:name => $name, :symbol => $symbol, :valence => $valence)
-end
-
-for (_, atom, symbol, valence) in atoms
+for (name, symbol, valence) in [values(atom) for atom in atoms_data]
     @eval begin
-        type $atom{T<:Number} <: AtomicUnit{T}
+        type $name{T<:Number} <: AtomicUnit{T}
             value::Complex{T}    # atomic value
             valence::Int         # number of valence electrons
             degree::Int          # number of shared valence electons
             free::Int            # number of free valence electrons
 
-            $atom(value) = new(value, $valence, 0, $valence)
+            $name(value) = new(value, $valence, 0, $valence)
         end
 
-        $atom{T<:Real}(value::Complex{T}) = $atom{T}(value)
-        $atom{T<:Real}(value::T) = $atom(complex(value))
-        $atom() = $atom(0.0)
+        $name{T<:Real}(value::Complex{T}) = $name{T}(value)
+        $name{T<:Real}(value::T) = $name(complex(value))
+        $name() = $name(0.0)
 
-        typealias $symbol $atom
+        typealias $symbol $name
     end
 end
 
-for atom in [atoms["name"] for atom in atoms]
-    @eval function promote_rule{T<:Real, S<:Real}(::Type{${T}}, ::Type{Carbon{S}}) = Carbon{promote_type(T, S)}
+for name in [atom[:name] for atom in atoms_data]
+    @eval function promote_rule{T<:Real, S<:Real}(::Type{$name{T}}, ::Type{$name{S}})
+        $name{promote_type(T, S)}
+    end
+end
 
 function Base.show(io::IO, a::AtomicUnit)
     print(io, "$(typeof(a))(value = $(a.value), valence = $(a.valence), degree = $(a.degree), free = $(a.free))")

--- a/src/atomic_units.jl
+++ b/src/atomic_units.jl
@@ -1,20 +1,12 @@
 abstract AtomicUnit{T}
 
-const atoms_meta = [
+const atoms_data = [
     #     Name   Symbol  Valence
     (:Hydrogen,  :H,     1),
     (  :Carbon,  :C,     4)
 ]
 
-const atoms_data = [
-    @compat Dict(
-        :name => name,
-        :symbol => symbol,
-        :valence => valence
-    ) for (name, symbol, valence) in atoms_meta
-]
-
-for (name, symbol, valence) in [values(atom) for atom in atoms_data]
+for (name, symbol, valence) in atoms_data
     @eval begin
         type $name{T<:Number} <: AtomicUnit{T}
             value::Complex{T}    # atomic value
@@ -25,17 +17,15 @@ for (name, symbol, valence) in [values(atom) for atom in atoms_data]
             $name(value) = new(value, $valence, 0, $valence)
         end
 
+        typealias $symbol $name
+        
         $name{T<:Real}(value::Complex{T}) = $name{T}(value)
         $name{T<:Real}(value::T) = $name(complex(value))
         $name() = $name(0.0)
 
-        typealias $symbol $name
-    end
-end
-
-for name in [atom[:name] for atom in atoms_data]
-    @eval function promote_rule{T<:Real, S<:Real}(::Type{$name{T}}, ::Type{$name{S}})
-        $name{promote_type(T, S)}
+        function promote_rule{T<:Real, S<:Real}(::Type{$name{T}}, ::Type{$name{S}})
+            $name{promote_type(T, S)}
+        end
     end
 end
 

--- a/src/atomic_units.jl
+++ b/src/atomic_units.jl
@@ -1,12 +1,18 @@
 abstract AtomicUnit{T}
 
-atoms = [
-    #     Name   Symbol  Valence
-    (:Hydrogen,  :H,     1),
-    (  :Carbon,  :C,     4)
+const atoms_data = [
+    # Variable       Name   Symbol  Valence
+    (:hydrogen, :Hydrogen,  :H,     1),
+    (  :carbon,   :Carbon,  :C,     4)
 ]
 
-for (atom, sym, valence) in atoms
+const atoms = Dict{Symbol, Tuple}[]
+
+for (variable, name, symbol, valence) in atoms_data
+    @eval const $variable = Dict(:name => $name, :symbol => $symbol, :valence => $valence)
+end
+
+for (_, atom, symbol, valence) in atoms
     @eval begin
         type $atom{T<:Number} <: AtomicUnit{T}
             value::Complex{T}    # atomic value
@@ -21,9 +27,12 @@ for (atom, sym, valence) in atoms
         $atom{T<:Real}(value::T) = $atom(complex(value))
         $atom() = $atom(0.0)
 
-        typealias $sym $atom
+        typealias $symbol $atom
     end
 end
+
+for atom in [atoms["name"] for atom in atoms]
+    @eval function promote_rule{T<:Real, S<:Real}(::Type{${T}}, ::Type{Carbon{S}}) = Carbon{promote_type(T, S)}
 
 function Base.show(io::IO, a::AtomicUnit)
     print(io, "$(typeof(a))(value = $(a.value), valence = $(a.valence), degree = $(a.degree), free = $(a.free))")


### PR DESCRIPTION
## Example
- I want this:

``` julia
julia> [C(1), H(1.0), H(1//1), C(big(1))]
4-element Array{AtomicUnit{T},1}:
 Carbon{Int64}(value = 1 + 0im, valence = 4, degree = 0, free = 4)
 Hydrogen{Float64}(value = 1.0 + 0.0im, valence = 1, degree = 0, free = 1)
 Hydrogen{Rational{Int64}}(value = 1//1 + 0//1*im, valence = 1, degree = 0, free = 1)
 Carbon{BigInt}(value = 1 + 0im, valence = 4, degree = 0, free = 4)
```

to promote to `Array{AtomicUnit{BigFloat},1}` (with {`Complex{BigFloat}` atomic values) instead of  `Array{AtomicUnit{T},1}` for type stable usage with the `AtomicUnitSet`, analog to this:

``` julia
julia> [1, 1.0, 1//1, big(1)]
4-element Array{BigFloat,1}:
 1e+00
 1e+00
 1e+00
 1e+00

julia> map(complex, [1, 1.0, 1//1, big(1)])
4-element Array{Complex{BigFloat},1}:
 1e+00+0e+00im
 1e+00+0e+00im
 1e+00+0e+00im
 1e+00+0e+00im

julia> ans[1]
1e+00 with 256 bits of precision + 0e+00 with 256 bits of precisionim
```
- **Expected output**:

``` julia
julia> [C(1), H(1.0), H(1//1), C(big(1))]
4-element Array{AtomicUnit{BigFloat},1}:
 Carbon{BigFloat}(value = 1e+00 with 256 bits of precision + 0e+00 with 256 bits of precisionim, valence = 4, degree = 0, free = 4)
 Hydrogen{BigFloat}(value = 1e+00 with 256 bits of precision + 0e+00 with 256 bits of precisionim, valence = 1, degree = 0, free = 1)
 Hydrogen{BigFloat}(value = 1e+00 with 256 bits of precision + 0e+00 with 256 bits of precisionim, valence = 1, degree = 0, free = 1)
 Carbon{BigFloat}(value = 1e+00 with 256 bits of precision + 0e+00 with 256 bits of precisionim, valence = 4, degree = 0, free = 4)
```
